### PR TITLE
6 add acquisition type to jobsettings for smartspim extractor

### DIFF
--- a/src/aind_metadata_extractor/models/smartspim.py
+++ b/src/aind_metadata_extractor/models/smartspim.py
@@ -46,5 +46,6 @@ class SlimsMetadataModel(BaseModel):
 class SmartspimModel(BaseModel):
     """SmartSPIM extractor model for intermediate data structure"""
 
+    acquisition_type: str
     file_metadata: FileMetadataModel
     slims_metadata: SlimsMetadataModel

--- a/src/aind_metadata_extractor/smartspim/extractor.py
+++ b/src/aind_metadata_extractor/smartspim/extractor.py
@@ -33,7 +33,10 @@ class SmartspimExtractor:
         file_metadata_model = FileMetadataModel(**file_metadata)
         slims_metadata_model = SlimsMetadataModel(**slims_metadata)
 
-        smartspim_metadata = SmartspimModel(file_metadata=file_metadata_model, slims_metadata=slims_metadata_model)
+        smartspim_metadata = SmartspimModel(
+            acquisition_type=self.job_settings.acquisition_type,
+            file_metadata=file_metadata_model,
+            slims_metadata=slims_metadata_model)
 
         return smartspim_metadata.model_dump()
 

--- a/src/aind_metadata_extractor/smartspim/job_settings.py
+++ b/src/aind_metadata_extractor/smartspim/job_settings.py
@@ -16,6 +16,7 @@ class JobSettings(BaseJobSettings):
         default=None, description=("Deprecated, use input_source instead.")
     )
     subject_id: str
+    acquisition_type: str
 
     # Metadata names
     asi_filename: str = Field(
@@ -33,11 +34,3 @@ class JobSettings(BaseJobSettings):
     )
     metadata_service_path: str
 
-    # Optional field for SLIMS datetime
-    slims_datetime: Optional[str] = Field(
-        default=None,
-        description=(
-            "Datetime of the SLIMS entry, if not provided, the datetime "
-            "window will be extracted from the metadata file."
-        ),
-    )

--- a/tests/smartspim/test_extractor.py
+++ b/tests/smartspim/test_extractor.py
@@ -22,6 +22,7 @@ class TestSmartspimExtractor(unittest.TestCase):
             "subject_id": "804714",
             "metadata_service_path": "https://api.test.com/smartspim",
             "input_source": "/data/SmartSPIM_2025-08-19_15-03-00",
+            "acquisition_type": "some_acquisition_type",
         }
         self.job_settings = JobSettings(**job_settings_dict)
 
@@ -151,6 +152,7 @@ class TestSmartspimExtractor(unittest.TestCase):
             "subject_id": "804714",
             "metadata_service_path": "https://api.test.com/smartspim",
             "input_source": None,  # This will cause the error
+            "acquisition_type": "some_acquisition_type",
         }
         invalid_settings = JobSettings(**invalid_settings_dict)
 
@@ -168,6 +170,7 @@ class TestSmartspimExtractor(unittest.TestCase):
             "subject_id": "804714",
             "metadata_service_path": "https://api.test.com/smartspim",
             "input_source": ["/data/SmartSPIM_2025-08-19_15-03-00", "/data/additional_path"],
+            "acquisition_type": "some_acquisition_type",
         }
 
         list_settings = JobSettings(**list_settings_dict)

--- a/tests/smartspim/test_job_settings.py
+++ b/tests/smartspim/test_job_settings.py
@@ -14,6 +14,7 @@ class TestJobSettings(unittest.TestCase):
         self.valid_job_settings = {
             "subject_id": "804714",
             "metadata_service_path": "https://api.metadata.service.com/smartspim",
+            "acquisition_type": "some_acquisition_type",
             "input_source": "/data/SmartSPIM_2025-08-19_15-03-00",
         }
 
@@ -23,6 +24,7 @@ class TestJobSettings(unittest.TestCase):
 
         self.assertEqual(job_settings.job_settings_name, "SmartSPIM")
         self.assertEqual(job_settings.subject_id, "804714")
+        self.assertEqual(job_settings.acquisition_type, "some_acquisition_type")
         self.assertEqual(job_settings.metadata_service_path, "https://api.metadata.service.com/smartspim")
         self.assertEqual(job_settings.input_source, "/data/SmartSPIM_2025-08-19_15-03-00")
 
@@ -60,18 +62,6 @@ class TestJobSettings(unittest.TestCase):
 
         job_settings = JobSettings.model_validate(settings_data)
         self.assertEqual(job_settings.mdata_filename_json, "custom/metadata.json")
-
-    def test_optional_slims_datetime(self):
-        """Test optional SLIMS datetime field."""
-        job_settings = JobSettings.model_validate(self.valid_job_settings)
-        self.assertIsNone(job_settings.slims_datetime)
-
-        # Test with datetime provided
-        settings_data = self.valid_job_settings.copy()
-        settings_data["slims_datetime"] = "2025-08-19T19:03:00Z"
-
-        job_settings = JobSettings.model_validate(settings_data)
-        self.assertEqual(job_settings.slims_datetime, "2025-08-19T19:03:00Z")
 
     def test_deprecated_raw_dataset_path(self):
         """Test deprecated raw_dataset_path field."""


### PR DESCRIPTION
This PR adds the acquisition_type field to JobSettings so that it can be passed on to the mapper. This also removes an unused SLIMS datetime field which didn't appear in the mapper.