### PR TITLE
17 standardize a base extractor class

### DIFF
--- a/src/aind_metadata_extractor/bergamo/extractor.py
+++ b/src/aind_metadata_extractor/bergamo/extractor.py
@@ -12,10 +12,11 @@ from typing import Dict, List
 from ScanImageTiffReader import ScanImageTiffReader
 
 from aind_metadata_extractor.bergamo.settings import Settings
+from aind_metadata_extractor.core import BaseExtractor
 from aind_metadata_extractor.models.bergamo import ExtractedInfo, ExtractedInfoItem, RawImageInfo, TifFileGroup
 
 
-class Extractor:
+class Extractor(BaseExtractor):
     """Class to manage extracting metadata from files."""
 
     def __init__(self, settings: Settings):

--- a/src/aind_metadata_extractor/core.py
+++ b/src/aind_metadata_extractor/core.py
@@ -15,7 +15,7 @@ from typing import Optional, Union, List, Type, Tuple
 from pathlib import Path
 
 
-class BaseExtractor():
+class BaseExtractor:
     """Parent class for metadata extractors."""
 
     def _extract(self):
@@ -30,24 +30,24 @@ class BaseExtractor():
         """Save extraction results to a standardized JSON file."""
         if not hasattr(self, "metadata"):
             raise ValueError("No metadata found. Please run the job first.")
-        
+
         job_settings = getattr(self, "job_settings", None)
         if job_settings is None or getattr(job_settings, "output_directory", None) is None:
             raise ValueError("No output directory specified in job settings.")
-        
+
         job_settings.output_directory.mkdir(parents=True, exist_ok=True)
-        
+
         # Generate filename from the module's parent directory name
         # e.g., aind_metadata_extractor.mesoscope.extractor -> "mesoscope"
         module_path = self.__class__.__module__
-        module_parts = module_path.split('.')
+        module_parts = module_path.split(".")
         if len(module_parts) >= 2:
             folder_name = module_parts[-2]  # Get the parent folder name
         else:
             raise ValueError("Cannot determine folder name from module path.")
-        
+
         output_path = job_settings.output_directory / f"{folder_name}.json"
-        
+
         metadata = getattr(self, "metadata")
         with open(output_path, "w") as f:
             # Handle both pydantic models and plain dicts
@@ -55,7 +55,7 @@ class BaseExtractor():
                 json.dump(metadata.model_dump(), f, indent=4)
             else:
                 json.dump(metadata, f, default=str, indent=4)
-        
+
         logging.info(f"Metadata written to {output_path}")
 
 

--- a/src/aind_metadata_extractor/mesoscope/extractor.py
+++ b/src/aind_metadata_extractor/mesoscope/extractor.py
@@ -10,13 +10,14 @@ from typing import Tuple, Union
 import h5py as h5
 import tifffile
 
+from aind_metadata_extractor.core import BaseExtractor
 from aind_metadata_extractor.mesoscope.job_settings import JobSettings
 from aind_metadata_extractor.utils.camstim_sync.camstim import Camstim, CamstimSettings
 
 from aind_metadata_extractor.models.mesoscope import MesoscopeExtractModel
 
 
-class MesoscopeExtract:
+class MesoscopeExtract(BaseExtractor):
     """Class to manage transforming mesoscope platform json and metadata into
     a mesoscope model model."""
 
@@ -193,22 +194,19 @@ class MesoscopeExtract:
             self.camstim.build_stimulus_table(modality="ophys")
         return self.camstim.epochs_from_stim_table(), self.camstim.session_type
 
-    def run_job(self) -> None:
+    def run_job(self) -> dict:
         """
-        Run the etl job
-        Returns
-        -------
-        None
+        Run the extraction job.
         """
         data = self._extract()
-        mesoscope_metadata = MesoscopeExtractModel(
+        self.metadata = MesoscopeExtractModel(
             tiff_header=data["time_series_header"],
             session_metadata=data["session_metadata"],
             camstim_epchs=data["camstim_epochs"],
             camstim_session_type=data["camstim_session_type"],
             job_settings=data["job_settings"],
         )
-        return mesoscope_metadata.model_dump()
+        return self.metadata.model_dump()
 
     @classmethod
     def from_args(cls, args: list):

--- a/src/aind_metadata_extractor/smartspim/extractor.py
+++ b/src/aind_metadata_extractor/smartspim/extractor.py
@@ -5,9 +5,11 @@ import os
 import re
 from typing import Optional
 from pathlib import Path
+import json
 
 import requests
 
+from aind_metadata_extractor.core import BaseExtractor
 from aind_metadata_extractor.smartspim.job_settings import JobSettings
 from aind_metadata_extractor.models.smartspim import SmartspimModel, FileMetadataModel, SlimsMetadataModel
 from aind_metadata_extractor.smartspim.utils import get_excitation_emission_waves, get_session_end, read_json_as_dict
@@ -16,14 +18,20 @@ REGEX_DATE = r"(20[0-9]{2})-([0-9]{2})-([0-9]{2})_([0-9]{2})-" r"([0-9]{2})-([0-
 REGEX_MOUSE_ID = r"([0-9]{6})"
 
 
-class SmartspimExtractor:
+class SmartspimExtractor(BaseExtractor):
     """Extractor for SmartSPIM metadata from microscope files and SLIMS."""
 
     def __init__(self, job_settings: JobSettings):
         """Initialize the SmartSPIM extractor with job settings."""
+        self.metadata = None
         self.job_settings = job_settings
 
-    def extract(self) -> dict:
+    def run_job(self):
+        """Run the extraction job."""
+        self.metadata = self._extract()
+        return self.metadata
+
+    def _extract(self) -> dict:
         """Run extraction process"""
 
         file_metadata = self._extract_metadata_from_microscope_files()

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -2,12 +2,13 @@
 
 import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Literal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, mock_open
 
-from aind_metadata_extractor.core import BaseJobSettings
+from aind_metadata_extractor.core import BaseJobSettings, BaseExtractor
 
 RESOURCES_DIR = Path(os.path.dirname(os.path.realpath(__file__))) / ".." / "resources"
 CONFIG_FILE_PATH = RESOURCES_DIR / "job_settings.json"
@@ -73,6 +74,198 @@ class TestJobSettings(unittest.TestCase):
 
         with self.assertRaises(Exception):
             self.MockJobSettings.from_args(args)
+
+
+class TestBaseExtractor(unittest.TestCase):
+    """Tests for BaseExtractor class"""
+
+    class MockExtractor(BaseExtractor):
+        """Mock extractor for testing purposes"""
+
+        def __init__(self, job_settings=None, metadata=None):
+            self.job_settings = job_settings
+            self.metadata = metadata
+
+        def _extract(self):
+            """Mock implementation"""
+            pass
+
+        def run_job(self):
+            """Mock implementation"""
+            pass
+
+    class MockJobSettings:
+        """Mock job settings for testing"""
+
+        def __init__(self, output_directory=None):
+            self.output_directory = Path(output_directory) if output_directory else None
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.temp_path = Path(self.temp_dir)
+
+    def tearDown(self):
+        """Clean up test fixtures"""
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_write_success_with_pydantic_model(self):
+        """Test successful write with pydantic model metadata"""
+        # Create mock metadata with model_dump method (pydantic model)
+        mock_metadata = MagicMock()
+        mock_metadata.model_dump.return_value = {"key": "value", "number": 42}
+
+        # Create extractor with proper module path
+        extractor = self.MockExtractor()
+        extractor.__class__.__module__ = "aind_metadata_extractor.mesoscope.extractor"
+        extractor.job_settings = self.MockJobSettings(self.temp_dir)
+        extractor.metadata = mock_metadata
+
+        # Mock open and json.dump
+        with patch("builtins.open", mock_open()) as mock_file, \
+             patch("json.dump") as mock_json_dump, \
+             patch("logging.info") as mock_log:
+
+            extractor.write()
+
+            # Verify file operations
+            expected_path = self.temp_path / "mesoscope.json"
+            mock_file.assert_called_once_with(expected_path, "w")
+            mock_json_dump.assert_called_once_with(
+                {"key": "value", "number": 42}, mock_file.return_value.__enter__.return_value, indent=4
+            )
+            mock_log.assert_called_once_with(f"Metadata written to {expected_path}")
+
+    def test_write_success_with_dict_metadata(self):
+        """Test successful write with dictionary metadata"""
+        # Create dictionary metadata (no model_dump method)
+        dict_metadata = {"key": "value", "list": [1, 2, 3]}
+
+        # Create extractor with proper module path
+        extractor = self.MockExtractor()
+        extractor.__class__.__module__ = "aind_metadata_extractor.bergamo.extractor"
+        extractor.job_settings = self.MockJobSettings(self.temp_dir)
+        extractor.metadata = dict_metadata
+
+        # Mock open and json.dump
+        with patch("builtins.open", mock_open()) as mock_file, \
+             patch("json.dump") as mock_json_dump, \
+             patch("logging.info") as mock_log:
+
+            extractor.write()
+
+            # Verify file operations
+            expected_path = self.temp_path / "bergamo.json"
+            mock_file.assert_called_once_with(expected_path, "w")
+            mock_json_dump.assert_called_once_with(
+                dict_metadata, mock_file.return_value.__enter__.return_value, default=str, indent=4
+            )
+            mock_log.assert_called_once_with(f"Metadata written to {expected_path}")
+
+    def test_write_creates_output_directory(self):
+        """Test that write creates output directory if it doesn't exist"""
+        nested_dir = self.temp_path / "nested" / "directory"
+        
+        extractor = self.MockExtractor()
+        extractor.__class__.__module__ = "aind_metadata_extractor.smartspim.extractor"
+        extractor.job_settings = self.MockJobSettings(nested_dir)
+        extractor.metadata = {"test": "data"}
+
+        with patch("builtins.open", mock_open()), \
+             patch("json.dump"), \
+             patch("logging.info"):
+
+            extractor.write()
+
+            # Verify directory was created
+            self.assertTrue(nested_dir.exists())
+            self.assertTrue(nested_dir.is_dir())
+
+    def test_write_no_metadata_raises_error(self):
+        """Test that write raises ValueError if no metadata exists"""
+        extractor = self.MockExtractor()
+        extractor.__class__.__module__ = "aind_metadata_extractor.test.extractor"  # Valid module path
+        extractor.job_settings = self.MockJobSettings(self.temp_dir)
+        # Explicitly remove metadata attribute
+        if hasattr(extractor, 'metadata'):
+            delattr(extractor, 'metadata')
+
+        with self.assertRaises(ValueError) as context:
+            extractor.write()
+
+        self.assertEqual(str(context.exception), "No metadata found. Please run the job first.")
+
+    def test_write_no_job_settings_raises_error(self):
+        """Test that write raises ValueError if no job_settings exists"""
+        extractor = self.MockExtractor()
+        extractor.metadata = {"test": "data"}
+        # Don't set job_settings
+
+        with self.assertRaises(ValueError) as context:
+            extractor.write()
+
+        self.assertEqual(str(context.exception), "No output directory specified in job settings.")
+
+    def test_write_no_output_directory_raises_error(self):
+        """Test that write raises ValueError if no output_directory in job_settings"""
+        extractor = self.MockExtractor()
+        extractor.job_settings = self.MockJobSettings(None)  # output_directory is None
+        extractor.metadata = {"test": "data"}
+
+        with self.assertRaises(ValueError) as context:
+            extractor.write()
+
+        self.assertEqual(str(context.exception), "No output directory specified in job settings.")
+
+    def test_write_invalid_module_path_raises_error(self):
+        """Test that write raises ValueError for invalid module path"""
+        extractor = self.MockExtractor()
+        extractor.__class__.__module__ = "invalid_module"  # Not enough parts
+        extractor.job_settings = self.MockJobSettings(self.temp_dir)
+        extractor.metadata = {"test": "data"}
+
+        with self.assertRaises(ValueError) as context:
+            extractor.write()
+
+        self.assertEqual(str(context.exception), "Cannot determine folder name from module path.")
+
+    def test_write_filename_generation(self):
+        """Test that filename is correctly generated from module path"""
+        test_cases = [
+            ("aind_metadata_extractor.mesoscope.extractor", "mesoscope.json"),
+            ("aind_metadata_extractor.bergamo.extractor", "bergamo.json"),
+            ("aind_metadata_extractor.smartspim.extractor", "smartspim.json"),
+            ("some.package.fip.module", "fip.json"),
+        ]
+
+        for module_path, expected_filename in test_cases:
+            with self.subTest(module_path=module_path):
+                extractor = self.MockExtractor()
+                extractor.__class__.__module__ = module_path
+                extractor.job_settings = self.MockJobSettings(self.temp_dir)
+                extractor.metadata = {"test": "data"}
+
+                with patch("builtins.open", mock_open()) as mock_file, \
+                     patch("json.dump"), \
+                     patch("logging.info"):
+
+                    extractor.write()
+
+                    expected_path = self.temp_path / expected_filename
+                    mock_file.assert_called_with(expected_path, "w")
+
+    def test_abstract_methods_not_implemented(self):
+        """Test that abstract methods raise NotImplementedError"""
+        extractor = BaseExtractor()
+
+        with self.assertRaises(NotImplementedError) as context:
+            extractor._extract()
+        self.assertEqual(str(context.exception), "This method should be implemented by subclasses.")
+
+        with self.assertRaises(NotImplementedError) as context:
+            extractor.run_job()
+        self.assertEqual(str(context.exception), "This method should be implemented by subclasses.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR standardizes a BaseExtractor class with the functions:

- _extract() which runs the actual data loading/extraction, returning a model
- run_job which uses the settings to do stuff, stores the the metadata in self.metadata, and returns a dictionary
- write() which is inherited, always writes a file with the name of the extractor module you are in with the contents of self.metadata