### PR TITLE
Add package-data configuration to include JSON schema files in distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ fip = ["aind-physiology-fip[data]"]
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+aind_metadata_extractor = ["models/*.json"]
+
 [tool.setuptools.dynamic]
 version = {attr = "aind_metadata_extractor.__version__"}
 


### PR DESCRIPTION
I couldn't figure out why github ci/cd kept failing when trying to import the fip json schema file from this repo, despite everything passing locally. Turns out that json files weren't being included in the build, so the schema file was not present when installing from pypi. This PR solves that.