### PR TITLE
fix(camstim): select photodiode edge phase

### DIFF
--- a/src/aind_metadata_extractor/utils/camstim_sync/stim_utils.py
+++ b/src/aind_metadata_extractor/utils/camstim_sync/stim_utils.py
@@ -587,6 +587,100 @@ def calculate_frame_mean_time(sync_file, frame_keys):
     return ptd_start, ptd_end
 
 
+def _select_photodiode_delay(
+    vsync_times,
+    rising_times,
+    falling_times,
+    frames_per_photodiode_cycle=120,
+    maximum_delay_seconds=0.1,
+    minimum_required_matches=3,
+):
+    """Select the photodiode edge phase that follows stimulus frame zero.
+
+    The photodiode square can begin in either state. Its state immediately
+    before the first stimulus vsync predicts whether a rising or falling edge
+    should report the first displayed transition. The predicted polarity is
+    accepted only when it follows frame zero within the monitor-delay window
+    and recurs at the expected photodiode cycle.
+
+    Parameters
+    ----------
+    vsync_times : np.ndarray
+        Falling stimulus-vsync times in seconds.
+    rising_times, falling_times : np.ndarray
+        Photodiode transition times in seconds.
+    frames_per_photodiode_cycle : int, optional
+        Number of stimulus frames between same-polarity transitions.
+    maximum_delay_seconds : float, optional
+        Largest plausible delay between a stimulus frame and photodiode edge.
+    minimum_required_matches : int, optional
+        Minimum number of recurring transitions needed to accept a polarity.
+
+    Returns
+    -------
+    delay : float or None
+        Mean monitor delay for the selected edge phase, or ``None`` when no
+        polarity passes the timing and recurrence checks.
+    """
+    if len(vsync_times) == 0:
+        return None
+
+    # The most recent transition before frame zero determines the line state,
+    # and therefore which polarity should occur next.
+    frame_zero_time = vsync_times[0]
+    rising_edges_before_frame_zero = np.searchsorted(rising_times, frame_zero_time)
+    falling_edges_before_frame_zero = np.searchsorted(falling_times, frame_zero_time)
+    last_rising_time = (
+        rising_times[rising_edges_before_frame_zero - 1] if rising_edges_before_frame_zero else -np.inf
+    )
+    last_falling_time = (
+        falling_times[falling_edges_before_frame_zero - 1] if falling_edges_before_frame_zero else -np.inf
+    )
+    preferred_edge_times = falling_times if last_rising_time > last_falling_time else rising_times
+    alternate_edge_times = rising_times if preferred_edge_times is falling_times else falling_times
+
+    # Same-polarity photodiode transitions should align with stimulus frames
+    # separated by the configured photodiode cycle.
+    expected_transition_times = vsync_times[::frames_per_photodiode_cycle]
+
+    for candidate_edge_times in (preferred_edge_times, alternate_edge_times):
+        # Find the first candidate photodiode edge at or after each expected
+        # transition time.
+        following_edge_indexes = np.searchsorted(candidate_edge_times, expected_transition_times)
+
+        # Exclude expected transitions after the final recorded edge. For the
+        # rest, subtraction gives the monitor delay for each candidate pair.
+        has_following_edge_mask = following_edge_indexes < len(candidate_edge_times)
+        candidate_delays_seconds = (
+            candidate_edge_times[following_edge_indexes[has_following_edge_mask]]
+            - expected_transition_times[has_following_edge_mask]
+        )
+
+        # Mark candidate pairs whose delay falls in the monitor-response
+        # window, then measure how consistently this polarity matches.
+        plausible_delay_mask = np.logical_and(
+            candidate_delays_seconds >= 0,
+            candidate_delays_seconds <= maximum_delay_seconds,
+        )
+        plausible_delays_seconds = candidate_delays_seconds[plausible_delay_mask]
+        required_matches = min(minimum_required_matches, len(expected_transition_times))
+        plausible_match_fraction = (
+            len(plausible_delays_seconds) / len(candidate_delays_seconds) if len(candidate_delays_seconds) else 0
+        )
+
+        # Require frame zero to match and at least 90% recurrence; boundary
+        # transitions near the end of a stimulus need not follow the cycle.
+        if (
+            len(plausible_delay_mask)
+            and plausible_delay_mask[0]
+            and len(plausible_delays_seconds) >= required_matches
+            and plausible_match_fraction >= 0.9
+        ):
+            return float(np.mean(plausible_delays_seconds))
+
+    return None
+
+
 def extract_frame_times_with_delay(
     sync_file,
     frame_keys=FRAME_KEYS,
@@ -624,6 +718,22 @@ def extract_frame_times_with_delay(
         sync.get_rising_edges(sync_file, "stim_photodiode"),
         dtype=np.float64,
     ) / float(sample_freq)
+    try:
+        photodiode_fall = np.array(
+            sync.get_falling_edges(sync_file, "stim_photodiode"),
+            dtype=np.float64,
+        ) / float(sample_freq)
+        selected_delay = _select_photodiode_delay(
+            stim_vsync_fall,
+            photodiode_rise,
+            photodiode_fall,
+        )
+    except (KeyError, TypeError, ValueError):
+        logger.debug("Unable to validate both photodiode edge phases; using legacy delay calculation", exc_info=True)
+        selected_delay = None
+    if selected_delay is not None:
+        logger.info("Monitor delay selected from validated photodiode edge phase")
+        return selected_delay
 
     # Find start and stop of stimulus
     # test and correct for photodiode transition errors

--- a/tests/utils/test_stim_utils.py
+++ b/tests/utils/test_stim_utils.py
@@ -806,49 +806,57 @@ class TestStimUtils(unittest.TestCase):
             # Function can return None if conditions aren't met
             self.assertIsNone(result)
 
-    @patch("aind_metadata_extractor.utils.camstim_sync.sync_utils.get_edges")
+    @patch("aind_metadata_extractor.utils.camstim_sync.sync_utils.get_falling_edges")
     @patch("aind_metadata_extractor.utils.camstim_sync.sync_utils.get_rising_edges")
-    def test_extract_frame_times_with_delay(self, mock_get_rising_edges, mock_get_edges):
-        """
-        Test the extract_frame_times_with_delay function.
-        """
-        # Mock vsync falling edges
-        mock_vsync_edges = np.array([100000, 200000, 300000, 400000, 500000]) / 100000.0
-        mock_get_edges.return_value = mock_vsync_edges
+    @patch("aind_metadata_extractor.utils.camstim_sync.sync_utils.get_edges")
+    def test_extract_frame_times_with_delay_uses_rising_phase(
+        self,
+        mock_get_edges,
+        mock_get_rising_edges,
+        mock_get_falling_edges,
+    ):
+        """A low photodiode state at frame zero selects rising edges."""
+        vsync_times = np.arange(0, 6, 1 / 60)
+        mock_get_edges.return_value = vsync_times
+        mock_get_rising_edges.return_value = np.array([0.024, 2.024, 4.024]) * 100000
+        mock_get_falling_edges.return_value = np.array([1.024, 3.024, 5.024]) * 100000
 
-        # Mock photodiode rising edges that align reasonably with vsync
-        mock_photodiode_edges = np.array(
-            [
-                105000,  # Slightly after first vsync
-                205000,  # Slightly after second vsync
-                305000,  # Slightly after third vsync
-                405000,  # Slightly after fourth vsync
-            ]
-        )
-        mock_get_rising_edges.return_value = mock_photodiode_edges
+        delay = stim.extract_frame_times_with_delay("mock_sync_file")
 
-        # Mock sync file
-        mock_sync_file = "mock_sync_file"
+        self.assertAlmostEqual(delay, 0.024)
 
-        # Call the function
-        result = stim.extract_frame_times_with_delay(mock_sync_file)
+    @patch("aind_metadata_extractor.utils.camstim_sync.sync_utils.get_falling_edges")
+    @patch("aind_metadata_extractor.utils.camstim_sync.sync_utils.get_rising_edges")
+    @patch("aind_metadata_extractor.utils.camstim_sync.sync_utils.get_edges")
+    def test_extract_frame_times_with_delay_uses_falling_phase(
+        self,
+        mock_get_edges,
+        mock_get_rising_edges,
+        mock_get_falling_edges,
+    ):
+        """A high photodiode state at frame zero selects falling edges."""
+        vsync_times = np.arange(0, 6, 1 / 60)
+        mock_get_edges.return_value = vsync_times
+        mock_get_rising_edges.return_value = np.array([-1, 1.02, 3.02, 5.02]) * 100000
+        mock_get_falling_edges.return_value = np.array([0.02, 2.02, 4.02]) * 100000
 
-        # Verify sync utilities were called correctly
-        mock_get_edges.assert_called_once_with(mock_sync_file, "falling", stim.FRAME_KEYS)
-        mock_get_rising_edges.assert_called_with(mock_sync_file, "stim_photodiode")
-        # Note: get_rising_edges is called multiple times in this function
+        delay = stim.extract_frame_times_with_delay("mock_sync_file")
 
-        # Function can return either a delay value (float) or array of times
-        if isinstance(result, (float, int)):
-            # Error case - returns ASSUMED_DELAY
-            self.assertIsInstance(result, (float, int))
-        else:
-            # Success case - returns array of frame times
-            self.assertIsInstance(result, np.ndarray)
-            self.assertEqual(len(result), len(mock_vsync_edges))
+        self.assertAlmostEqual(delay, 0.02)
 
-            # Results should be close to original vsync times (possibly with delay adjustment)
-            self.assertTrue(np.allclose(result, mock_vsync_edges, atol=0.1))
+    def test_select_photodiode_delay_rejects_missing_frame_zero_edge(self):
+        """Regular later edges cannot compensate for a missing frame-zero edge."""
+        vsync_times = np.arange(0, 6, 1 / 60)
+        rising_times = np.array([2.024, 4.024])
+        falling_times = np.array([1.024, 3.024, 5.024])
+
+        delay = stim._select_photodiode_delay(vsync_times, rising_times, falling_times)
+
+        self.assertIsNone(delay)
+
+        delay = stim._select_photodiode_delay(vsync_times, np.array([]), np.array([]))
+
+        self.assertIsNone(delay)
 
     def test_enforce_df_int_typing_fillna_path(self):
         """


### PR DESCRIPTION
## Summary
- select rising or falling photodiode edges from the line state at frame zero
- validate the selected phase with the monitor-delay window and recurring same-polarity transitions
- retain the legacy delay calculation when dual-polarity validation is unavailable
- add regression coverage for rising phase, falling phase, missing frame-zero transitions, and empty edge arrays

## Validation
- `PYTHONPATH=src:tests python -m unittest tests.utils.test_stim_utils tests.utils.test_camstim -q` (64 tests pass)
- regenerated synchronization tables and packaged NWBs for four sessions
- receptive-field offset sweeps for all four sessions peak at `0.0 s`